### PR TITLE
Read configuration from file instead of environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,15 @@ A slack bot that will fetch type signatures via Hoogle:
 
 <img src="http://i.imgur.com/TJzSA93.png" width="400">
 
-## Deployment + Configuration
+## Configuration
 
-First, run the following:
+* Create a custom outgoing webhook integration in slack, and save the token.
+* Create a custom incoming webook integration in slack, and save the URL.
+* Configure the app.cfg as:
 
-```bash
-$ git clone https://github.com/thoughtbot/typebot.git
-$ cd typebot
-$ heroku create --buildpack https://github.com/mfine/heroku-buildpack-stack.git
-$ heroku ps:scale web=1
-$ git push heroku master
+```
+token="URL"
 ```
 
-This will give you the URL typebot is deployed at. If you `curl` the URL, you
-should get a 200 response.
-
-Go to your team's slack, and then Custom Integrations > Outgoing Webhooks. Set
-the channel to whatever channel you wish, the trigger word to :t, and the URL to
-your Heroku URL + `/type`. Grab the Token, and set that as the
-`TYPEBOT_SLACK_TOKEN` environment variable on Heroku.
-
-<img src="http://i.imgur.com/mLIScKq.png" width="800">
-
-Then, go to Custom Integrations > Incoming Webhooks. Set the channel to be
-whatever channel you want typebot to post to. Copy the Webhook URL, and set that
-as the `TYPEBOT_SLACK_URL` environment variable on Heroku. All done!
+You can have the same bot service multiple slack teams by adding additional
+`token="URL"` lines. Deploy to your favorite server/provider.

--- a/app.cfg
+++ b/app.cfg
@@ -1,0 +1,1 @@
+token="http://www.slack.com"

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -10,6 +10,7 @@ import           Data.Text.Lazy (toStrict, fromStrict)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Text.Lazy.Encoding (encodeUtf8)
 import           HTMLEntities.Decoder (htmlEncodedText)
+import           Network.HTTP.Base (urlEncode)
 import           Network.HTTP.Conduit
 import           Network.HTTP.Types.Status (Status(..))
 import           Network.URI (unEscapeString)
@@ -28,7 +29,7 @@ typeRequest :: Text -> S.ActionM ()
 typeRequest = maybe badRequest slackRequest <=< hoogle
 
 removeCommandChars :: Text -> Text
-removeCommandChars t = toHtmlEncodedText . snd . splitAt 5 $ unpack t
+removeCommandChars t = toHtmlEncodedText . urlEncode . snd . splitAt 5 $ unpack t
 
 toText = toStrict . toLazyText
 toHtmlEncodedText = toText . htmlEncodedText . pack . unEscapeString

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -2,11 +2,14 @@
 
 module Bot (runApp) where
 
+import           Control.Monad ((<=<), void)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Control.Monad ((<=<))
+import           Control.Monad.Reader (MonadReader, ReaderT, ask, lift, runReaderT)
 import           Data.Aeson (decode)
+import           Data.Configurator as C
+import           Data.Configurator.Types (Config)
+import           Data.Default.Class (def)
 import           Data.Text (Text(..), unpack, pack)
-import           Data.Text.Lazy (toStrict, fromStrict)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Text.Lazy.Encoding (encodeUtf8)
 import           HTMLEntities.Decoder (htmlEncodedText)
@@ -15,23 +18,26 @@ import           Network.HTTP.Conduit
 import           Network.HTTP.Types.Status (Status(..))
 import           Network.URI (unEscapeString)
 import           Network.Wai (Application)
+import           Network.Wai.Handler.Warp (setPort)
 import           System.Environment (getEnv)
 import           Types
 import           Utils
+import           Web.Scotty.Trans (ScottyT, Options, get, post, scottyOptsT, status, settings)
+import qualified Data.Text.Lazy as L
 import qualified Web.Scotty as S
 
-app' :: S.ScottyM ()
+app' :: ScottyT L.Text ConfigM ()
 app' = do
-  S.get "/" $ S.status $ Status 200 "OK"
-  S.post "/type" $ authorized $ requireParameter "text" typeRequest
+  get "/" $ status $ Status 200 "OK"
+  post "/type" $ authorized $ requireParameter "text" typeRequest
 
-typeRequest :: Text -> S.ActionM ()
+typeRequest :: Text -> TypeBot ()
 typeRequest = maybe badRequest slackRequest <=< hoogle
 
 removeCommandChars :: Text -> Text
 removeCommandChars t = toHtmlEncodedText . urlEncode . snd . splitAt 5 $ unpack t
 
-toText = toStrict . toLazyText
+toText = L.toStrict . toLazyText
 toHtmlEncodedText = toText . htmlEncodedText . pack . unEscapeString
 
 functionNameToUrl :: Text -> String
@@ -46,14 +52,16 @@ hoogle f = liftIO $ do
   response <- simpleHttp . functionNameToUrl $ removeCommandChars f
   return $ firstType =<< decode response
 
-slackRequest :: (MonadIO m) => SearchResult -> m ()
-slackRequest s = liftIO $ do
-  slackUrl <- getEnv "TYPEBOT_SLACK_URL"
-  request <- parseUrl slackUrl
-  let req = request { method = "POST", requestBody = requestBodyLbs $ jsonPayload s }
-  manager <- newManager tlsManagerSettings
-  httpLbs req manager
-  return ()
+slackRequest :: SearchResult -> TypeBot ()
+slackRequest s = do
+  cfg <- lift ask
+  (Just rToken) <- lookupParameter "token"
+  liftIO $ do
+    slackUrl <- C.require cfg rToken
+    request <- parseUrl slackUrl
+    let req = request { method = "POST", requestBody = requestBodyLbs $ jsonPayload s }
+    manager <- newManager tlsManagerSettings
+    void $ httpLbs req manager
 
 jsonPayload :: SearchResult -> [String]
 jsonPayload s = typePayload s ++ hoogleURL s ++ ["\" }"]
@@ -72,7 +80,17 @@ hoogleURL (SearchResult _ locationURL)
   | not (null locationURL) = ["Hackage docs: ", locationURL]
   | otherwise = []
 
-requestBodyLbs = RequestBodyLBS . encodeUtf8 . fromStrict . pack . mconcat
+requestBodyLbs = RequestBodyLBS . encodeUtf8 . L.fromStrict . pack . mconcat
+
+opts :: IO Options
+opts = do
+  port <- webPort
+  return def { settings = setPort port $ settings def }
 
 runApp :: IO ()
-runApp = (`S.scotty` app') =<< webPort
+runApp = do
+  c <- C.load [Required "app.cfg"]
+  o <- opts
+  scottyOptsT o (runIO c) app' where
+    runIO :: Config -> ConfigM a -> IO a
+    runIO c m = runReaderT (runConfigM m) c

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,8 +1,14 @@
-{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Types where
 
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.Reader (MonadIO, MonadReader, ReaderT)
+import           Data.Configurator.Types
 import           Data.Aeson (FromJSON(parseJSON), Value(..), object, (.=), (.:))
+import           Web.Scotty.Trans (ActionT)
+import qualified Data.Text.Lazy as L
 
 data SearchResult = SearchResult { typeString :: String, locationURL :: String } deriving (Show)
 
@@ -13,3 +19,7 @@ newtype ResultList = ResultList [SearchResult] deriving (Show)
 
 instance FromJSON ResultList where
   parseJSON (Object v) = ResultList <$> v .: "results"
+
+newtype ConfigM a = ConfigM { runConfigM :: ReaderT Config IO a } deriving (Applicative, Functor, Monad, MonadIO, MonadReader Config)
+
+type TypeBot a = ActionT L.Text ConfigM a

--- a/typebot.cabal
+++ b/typebot.cabal
@@ -28,6 +28,7 @@ library
                      , http-conduit
                      , network-uri
                      , html-entities
+                     , HTTP
   default-language:    Haskell2010
 
 executable typebot-exe

--- a/typebot.cabal
+++ b/typebot.cabal
@@ -29,6 +29,10 @@ library
                      , network-uri
                      , html-entities
                      , HTTP
+                     , mtl
+                     , configurator
+                     , data-default-class
+                     , warp
   default-language:    Haskell2010
 
 executable typebot-exe


### PR DESCRIPTION
- Introduced `Configurator` to read config from file, instead of environment
- Introduced `Reader` into the Scotty stack to store config
### TODO
- Update README
- Pass port from environement into `scottyOptsT` ✅ 
