### PR TITLE
Match exactly ":t " when parsing requests

### DIFF
--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -54,10 +54,15 @@ humanFriendlyUrl Hoogle x = unpack $ [st|http://hayoo.fh-wedel.de/?query=#{x}|]
 noResultsSlack :: Text -> TypeBot ()
 noResultsSlack t = do
   s <- lift $ asks appSearchEngine
-  slack $ notFoundPayload s t
+  case (removeCommandChars t) of
+    Just t' -> slack $ notFoundPayload s t'
+    Nothing -> slack $ parseError
 
 notFoundPayload :: SearchEngine -> Text -> Text
-notFoundPayload s t = [st|{ "text": "I couldn't find a matching result, here's where I looked: #{humanFriendlyUrl s $ removeCommandChars t}" }|]
+notFoundPayload s t = [st|{ "text": "I couldn't find a matching result, here's where I looked: #{humanFriendlyUrl s t}" }|]
+
+parseError :: Text
+parseError = [st|{ "text": "I couldn't parse the your request..." }|]
 
 slackRequest :: SearchResult -> TypeBot ()
 slackRequest = slack . typePayload

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -40,7 +40,7 @@ app' = do
 typeRequest :: Text -> TypeBot ()
 typeRequest f = do
   s <- lift $ asks appSearchEngine
-  result <- search s $ f
+  result <- search s f
   maybe (noResultsSlack f) slackRequest result
 
 search :: (MonadIO m) => SearchEngine -> (Text -> m (Maybe SearchResult))
@@ -54,9 +54,9 @@ humanFriendlyUrl Hoogle x = unpack $ [st|http://hayoo.fh-wedel.de/?query=#{x}|]
 noResultsSlack :: Text -> TypeBot ()
 noResultsSlack t = do
   s <- lift $ asks appSearchEngine
-  case (removeCommandChars t) of
+  case removeCommandChars t of
     Just t' -> slack $ notFoundPayload s t'
-    Nothing -> slack $ parseError
+    Nothing -> slack parseError
 
 notFoundPayload :: SearchEngine -> Text -> Text
 notFoundPayload s t = [st|{ "text": "I couldn't find a matching result, here's where I looked: #{humanFriendlyUrl s t}" }|]

--- a/src/Providers/Hayoo.hs
+++ b/src/Providers/Hayoo.hs
@@ -40,8 +40,8 @@ hayooUrl x = unpack $ [st|http://hayoo.fh-wedel.de/json?query=#{x}|]
 
 hayoo :: (MonadIO m) => Text -> m (Maybe SearchResult)
 hayoo f = liftIO $ do
-  response <- simpleHttp . hayooUrl $ removeCommandChars f
-  return $ translateHayoo <$> (firstHayooResult =<< decode response)
+  response <- sequence $ simpleHttp . hayooUrl <$> removeCommandChars f
+  return $ translateHayoo <$> (firstHayooResult =<< decode =<< response)
 
 translateHayoo :: HayooResult -> SearchResult
 translateHayoo (HayooResult fn (Just ft) fl) = SearchResult (fn ++ " :: " ++ ft) fl

--- a/src/Providers/Hoogle.hs
+++ b/src/Providers/Hoogle.hs
@@ -39,8 +39,8 @@ hoogleUrl x = unpack $ [st|https://www.haskell.org/hoogle/?mode=json&hoogle=#{x}
 
 hoogle :: (MonadIO m) => Text -> m (Maybe SearchResult)
 hoogle f = liftIO $ do
-  response <- simpleHttp . hoogleUrl $ removeCommandChars f
-  return $ translateHoogle <$> (firstHoogleResult =<< decode response)
+  response <- sequence $ simpleHttp . hoogleUrl <$> removeCommandChars f
+  return $ translateHoogle <$> (firstHoogleResult =<< decode =<< response)
 
 translateHoogle :: HoogleResult -> SearchResult
 translateHoogle (HoogleResult ht hlurl) = SearchResult ht hlurl

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -6,7 +6,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Reader (ask, lift)
 import           Data.Default.Class (def)
 import           Data.Maybe (catMaybes, isJust, listToMaybe)
-import           Data.Text (splitOn, splitAt, unpack, pack, replace, Text)
+import           Data.Text (splitOn, unpack, pack, replace, Text)
 import           Data.Text.Internal.Builder(Builder)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Text.Lazy.Encoding (decodeUtf8)
@@ -67,10 +67,10 @@ webPort :: IO Int
 webPort = read <$> getEnv "PORT"
 
 removeCommandChars :: Text -> Maybe Text
-removeCommandChars t = urlEncode . toHtmlEncodedText . replacePlus <$> (parsedCommand' t)
+removeCommandChars t = urlEncode . toHtmlEncodedText . replacePlus <$> parsedCommand' t
   where
-    parsedCommand' t = pack . snd <$> parsedCommand t
-    parsedCommand t = listToMaybe $ (P.readP_to_S $ P.string "%3At+") $ unpack t
+    parsedCommand' t'' = pack . snd <$> parsedCommand t''
+    parsedCommand t' = listToMaybe $ P.readP_to_S (P.string "%3At+") $ unpack t'
 
 toText :: Builder -> Text
 toText = L.toStrict . toLazyText


### PR DESCRIPTION
Previously, typing `:thumbsup:` would trigger typebot because it listens for
strings starting with `:t`. Now, we ensure there is a space after `:t` using
`Text.ParserCombinators.ReadP`.

Fixes #13 
